### PR TITLE
Feature/aggregate data avg

### DIFF
--- a/config.js
+++ b/config.js
@@ -66,7 +66,7 @@ config.database = {
   password: '',
   // The URI to use for the database connection. It supports replica set URIs. This does not
   // include the "mongo://" protocol part. Default value: "localhost:27017"
-  URI: '192.168.99.100:31017',
+  URI: '192.168.99.100:31217',
   // The name of the replica set to connect to, if any. Default value: "".
   replicaSet: '',
   // The prefix to be added to the service for the creation of the databases. Default value: "sth".

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -2173,8 +2173,8 @@ function getAggrDataFromMapReduce(data, callback) {
     const makeNGSICompliant = (results) => {
         Object.keys(results).forEach(function (key) {
             results[key].recvTime = results[key].value.recvTime;
-            results[key].attrType = results[key].value.attrType;
-            results[key].attrValue = results[key].value.attrValue.toFixed(6).toString();
+            // results[key].attrType = results[key].value.attrType;
+            results[key].attrValue = results[key].value.attrValue;
             delete results[key].value;
             delete results[key]._id;
         });

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -1985,18 +1985,17 @@ function getAggrDataFromNativeAggregationPipeline(data, callback) {
         from = data.from,
         to = data.to;
 
-        //const timeZoneOffsetMillis = sthServerUtils.timeZoneOffsetMillis(from, 'Europe/Vienna');
-        const aggregationPipeline = sthServerUtils.aggregationPipelineBuilder(aggrMethod, aggrPeriod, hLimit, attrName, from, to);
+        const timeZoneOffsetMillis = sthServerUtils.timeZoneOffsetMillis(from, 'Europe/Vienna');
+        const aggrPipeline = sthServerUtils.aggregationPipelineBuilder(aggrMethod, aggrPeriod, hLimit, attrName, from, to, timeZoneOffsetMillis);
 
-
-        collection.aggregate(aggregationPipeline).toArray(function(err, results) {
+        collection.aggregate(aggrPipeline).toArray(function(err, results) {
             results.forEach(res => {
                 if (aggrPeriod === 'month') {
-                    res['recvTime'] = new Date(new Date(res['firstDate'].getTime()).setDate(1)).setHours(0, 0, 0, 0);
+                    res['recvTime'] = new Date(new Date(res['firstDate'].getTime()).setUTCDate(1)).setUTCHours(0, 0, 0, 0);
                 } else if (aggrPeriod === 'day') {
-                    res['recvTime'] = new Date(res['firstDate'].getTime()).setHours(0, 0, 0, 0);
+                    res['recvTime'] = new Date(res['firstDate'].getTime()).setUTCHours(0, 0, 0, 0);
                 } else if (aggrPeriod === 'hour') {
-                    res['recvTime'] = new Date(res['firstDate'].getTime()).setMinutes(0, 0, 0);
+                    res['recvTime'] = new Date(res['firstDate'].getTime()).setUTCMinutes(0, 0, 0);
                 }
                 res.recvTime = new Date(res.recvTime);
                 delete res._id;

--- a/lib/database/sthDatabase.js
+++ b/lib/database/sthDatabase.js
@@ -29,6 +29,7 @@ var ROOT_PATH = require('app-root-path').toString();
 var sthLogger = require('logops');
 var sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration.js');
 var sthUtils = require(ROOT_PATH + '/lib/utils/sthUtils.js');
+var sthServerUtils = require(ROOT_PATH + '/lib/server/utils/sthServerUtils.js');
 var sthDatabaseNaming = require(ROOT_PATH + '/lib/database/model/sthDatabaseNaming');
 var mongoClient = require('mongodb').MongoClient;
 var boom = require('boom');
@@ -38,7 +39,6 @@ var path = require('path');
 var mkdirp = require('mkdirp');
 var async = require('async');
 var _ = require('lodash');
-var moment = require('moment-timezone');
 
 var db, connectionURL;
 
@@ -525,10 +525,6 @@ function getRawData(data, callback) {
             });
         }
     }
-}
-
-function getCollectionNames(service, servicePath) {
-
 }
 
 /**
@@ -1974,6 +1970,44 @@ function removeData(data, callback) {
 }
 
 /**
+ * @IPPR - GetAggrDataFromNativePipeline
+ * Returns historical data in an aggregated fashion by using the native aggregation pipeline of mongodb
+ * Works with aggrMethod=[avg,min,max] and hLimit OR aggrMethod=[avg,min,max] and aggrPeriod=[m(onth),d(ay),h(our)]
+ * @param data
+ * @param callback
+ */
+function getAggrDataFromNativeAggregationPipeline(data, callback) {
+    const collection = data.collection,
+        attrName = data.attrName,
+        aggrMethod = data.aggrMethod,
+        aggrPeriod = data.aggrPeriod,
+        hLimit = data.hLimit,
+        from = data.from,
+        to = data.to;
+
+        //const timeZoneOffsetMillis = sthServerUtils.timeZoneOffsetMillis(from, 'Europe/Vienna');
+        const aggregationPipeline = sthServerUtils.aggregationPipelineBuilder(aggrMethod, aggrPeriod, hLimit, attrName, from, to);
+
+
+        collection.aggregate(aggregationPipeline).toArray(function(err, results) {
+            results.forEach(res => {
+                if (aggrPeriod === 'month') {
+                    res['recvTime'] = new Date(new Date(res['firstDate'].getTime()).setDate(1)).setHours(0, 0, 0, 0);
+                } else if (aggrPeriod === 'day') {
+                    res['recvTime'] = new Date(res['firstDate'].getTime()).setHours(0, 0, 0, 0);
+                } else if (aggrPeriod === 'hour') {
+                    res['recvTime'] = new Date(res['firstDate'].getTime()).setMinutes(0, 0, 0);
+                }
+                res.recvTime = new Date(res.recvTime);
+                delete res._id;
+                delete res.firstDate;
+            });
+            return process.nextTick(callback.bind(null, err, results));
+        });
+}
+
+
+/**
  * @IPPR
  * Returns historical data in an aggregated fashion by using MapReduce
  * Works with aggrMethod=[avg,min,max] and hLimit OR aggrMethod=[avg,min,max] and aggrPeriod=[m(onth),d(ay),h(our)]
@@ -1990,13 +2024,6 @@ function getAggrDataFromMapReduce(data, callback) {
         hLimit = data.hLimit,
         from = data.from,
         to = data.to;
-
-    const timeZoneOffsetMillis = function(utcDateTime) {
-        const utcDate = moment.utc(utcDateTime);
-        const local = moment.utc(utcDate).tz('Europe/Vienna');
-        const offset = local.utcOffset(); //in minutes
-        return offset * 60000;
-    };
 
     let findCondition;
     switch (sthConfig.DATA_MODEL) {
@@ -2042,7 +2069,7 @@ function getAggrDataFromMapReduce(data, callback) {
         id = 0; // = batchSize (represents the key that is used for the mapping and reducing)
     // TODO: Check if 'to' has the same offset as 'from' in order to not falsify recvTime dates when adding offsets!
     // e.g. if 'to' is affected by DST and 'from' is not, this will yield some recvTime's with false offsets (rare case)
-    const timezoneOffsetMillis = timeZoneOffsetMillis(from);
+    const timezoneOffsetMillis = sthServerUtils.timeZoneOffsetMillis(from, 'Europe/Vienna');
 
     const mapFunction = function () {
         const key = id;
@@ -2182,6 +2209,7 @@ module.exports = {
     getAggregateUpdateCondition: getAggregateUpdateCondition,
     getAggregatePrepopulatedData: getAggregatePrepopulatedData,
     getAggrDataFromMapReduce: getAggrDataFromMapReduce,
+    getAggrDataFromNativeAggregationPipeline: getAggrDataFromNativeAggregationPipeline,
     storeAggregatedData: storeAggregatedData,
     storeAggregatedData4Resolution: storeAggregatedData4Resolution,
     storeRawData: storeRawData,

--- a/lib/server/handlers/sthGetDataHandler.js
+++ b/lib/server/handlers/sthGetDataHandler.js
@@ -785,6 +785,169 @@ function multiMapReduceAggregation(request, reply) {
 
 }
 
+/**
+* @IPPR
+* Returns multiple historical data in an aggregated format by using native pipeline
+* This function runs independent of any NGSISTHSINK which has to create aggregated collections beforehand
+* as it aggregates data with the help of MapReduce functions (in-memory)
+* @param {Object}   request The request
+* @param {Function} reply   Hapi's reply function
+*/
+function multiNativeAggregationPipeline(request, reply) {
+    let response;
+    // temperature, humidity,...
+    const attrNames = request.params.attrName.split(',').length > 1 ? request.params.attrName.split(',') :
+        [request.params.attrName];
+    // Sensor names
+    const entityIds = request.params.entityId.split(',').length > 1 ? request.params.entityId.split(',') :
+        [request.params.entityId];
+
+    const collectionData = {};
+    const contextElements = [];
+    let totalMultiCount = 0;
+    let totalCallbackFunctions = entityIds.length * attrNames.length;
+
+    function generateMultiResponse() {
+        Object.keys(collectionData).forEach(entityId => {
+            if (request.query.nongsi) {
+                const contextElement = sthServerUtils.getLWJContextElement(entityId, request.params.entityType,
+                    collectionData[entityId]['attributes']);
+                contextElements.push(contextElement);
+            } else {
+                const contextElement = sthServerUtils.getNGSIMultiAttributesContextElement(entityId, request.params.entityType,
+                    collectionData[entityId]['attributes']);
+                contextElements.push(contextElement);
+            }
+        });
+
+        response = reply(request.query.nongsi ? sthServerUtils.getLWJPayload(contextElements) :
+            sthServerUtils.getNGSIMultiContextElementsPayload(contextElements));
+        sthServerUtils.addFiwareCorrelator(request, response);
+        sthServerUtils.addFiwareTotalCount(totalMultiCount, response);
+    }
+
+    function processAggrData(err, result, entityId, attrName) {
+        totalCallbackFunctions--;
+        if (err) {
+            // Error when getting the raw data
+            sthLogger.error(
+                request.sth.context,
+                'Error when getting aggregated data from collection \'%s\'',
+                collectionData[entityId].collection
+            );
+            sthLogger.debug(
+                request.sth.context,
+                'Responding with 500 - Internal Error'
+            );
+            response = reply(err);
+        } else if (!result || !result.length) {
+            // No raw data available for the request
+            sthLogger.debug(
+                request.sth.context,
+                'No aggregated data available for the entityId ' + entityId + 'and attribute ' + attrName
+            );
+
+            const emptyAttributePayload = {name: attrName, values: []};
+            collectionData[entityId]['attributes'].push(emptyAttributePayload);
+
+        } else {
+            sthLogger.debug(
+                request.sth.context,
+                'Responding with %s docs',
+                result.length
+            );
+
+            if (request.query.nongsi) {
+                const keyLessResultSet = result.map(res => Object.values(res));
+                const attributePayload = sthServerUtils.getLWJSingleAttributeResult(attrName, Object.keys(result[0]), keyLessResultSet);
+                collectionData[entityId]['attributes'].push(attributePayload);
+            } else {
+                const attributePayload = {name: attrName, values: result};
+                collectionData[entityId]['attributes'].push(attributePayload);
+            }
+        }
+        if (totalCallbackFunctions < 1) {
+            generateMultiResponse();
+        }
+    }
+
+    function getCollectionAggrData(entityId) {
+        attrNames.forEach(attrName => {
+            sthDatabase.getAggrDataFromNativeAggregationPipeline({
+                    collection: collectionData[entityId]['collection'],
+                    attrName: attrName,
+                    aggrMethod: request.query.aggrMethod,
+                    aggrPeriod: request.query.aggrPeriod,
+                    hLimit: request.query.hLimit,
+                    from: request.query.dateFrom,
+                    to: request.query.dateTo,
+                },
+                // cb function
+                (err, result) => processAggrData(err, result, entityId, attrName)
+            );
+        });
+    }
+
+    function processCollectionHandler(err, collection, entityId) {
+        if (err) {
+            // The collection does not exist, reply with en empty response
+            sthLogger.warn(
+                request.sth.context,
+                'Error when getting the data collection for retrieval (the collection \'%s\' may not exist)',
+                collection
+            );
+
+            sthLogger.debug(
+                request.sth.context,
+                'Responding with no points'
+            );
+
+            if (request.query.nongsi) {
+                const emptyResult = sthServerUtils.getLWJContextElement(entityId, request.params.entityType, []);
+                contextElements.push(emptyResult);
+            } else {
+                const emptyContextElement = sthServerUtils.getNGSIMultiAttributesContextElement(entityId,
+                    request.params.entityType, []);
+                contextElements.push(emptyContextElement);
+            }
+            totalCallbackFunctions -= attrNames.length;
+
+            if (totalCallbackFunctions < 1) {
+                generateMultiResponse();
+            }
+
+        } else {
+            sthLogger.debug(
+                request.sth.context,
+                `The raw data collection "${collection.s.namespace}" exists and is being processed`
+            );
+            collectionData[entityId]['collection'] = collection;
+            collectionData[entityId]['attributes'] = [];
+            getCollectionAggrData(entityId);
+        }
+    }
+
+    entityIds.forEach(entityId => {
+        collectionData[entityId] = {};
+        sthDatabase.getCollection(
+            {
+                service: request.headers[sthConfig.HEADER.FIWARE_SERVICE],
+                servicePath: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
+                entityId: entityId,
+                entityType: request.params.entityType,
+            },
+            {
+                isAggregated: false,
+                shouldCreate: false,
+                shouldTruncate: false
+            },
+            // cb function
+            (error, collection) => processCollectionHandler(error, collection, entityId)
+        );
+    });
+
+}
+
 
 /**
  * Handler for requests of historical raw and aggregated data
@@ -834,8 +997,12 @@ function getDataHandler(request, reply) {
     }
   } else if ((request.query.aggrMethod && request.query.hLimit && !request.query.aggrPeriod) ||
       (request.query.aggrMethod && request.query.aggrPeriod && !request.query.hLimit)) {
-      request.params.entityId.split(',').length > 1 || request.params.attrName.split(',').length > 1 ?
-          multiMapReduceAggregation(request, reply) : /*mapReduceAggregation(request, reply);*/ nativePipelineAggregation(request, reply);
+      if (request.params.entityId.split(',').length > 1 || request.params.attrName.split(',').length > 1) {
+          request.query.nativeAggr ? multiNativeAggregationPipeline(request, reply) : multiMapReduceAggregation(request, reply);
+      } else {
+          request.query.nativeAggr ? nativePipelineAggregation(request, reply) : mapReduceAggregation(request, reply);
+      }
+      // multiMapReduceAggregation(request, reply) : /*mapReduceAggregation(request, reply);*/ nativePipelineAggregation(request, reply);
   } else if (request.query.aggrMethod && request.query.aggrPeriod) {
     // Aggregated data is requested
     getAggregatedData(request, reply);

--- a/lib/server/handlers/sthGetDataHandler.js
+++ b/lib/server/handlers/sthGetDataHandler.js
@@ -567,6 +567,61 @@ function mapReduceAggregation(request, reply) {
 
 /**
  * @IPPR
+ * Returns historical data in an aggregated format by using the native aggregation pipeline framework of mongodb
+ * This function runs independent of any NGSISTHSINK which has to create aggregated collections beforehand
+ * as it aggregates data with the help of MapReduce functions (in-memory)
+ * @param {Object}   request The request
+ * @param {Function} reply   Hapi's reply function
+ */
+function nativePipelineAggregation(request, reply) {
+    sthDatabase.getCollection(
+        {
+            service: request.headers[sthConfig.HEADER.FIWARE_SERVICE],
+            servicePath: request.headers[sthConfig.HEADER.FIWARE_SERVICE_PATH],
+            entityId: request.params.entityId,
+            entityType: request.params.entityType,
+            attrName: request.params.attrName
+        },
+        {
+            isAggregated: false,
+            shouldCreate: false,
+            shouldTruncate: false
+        },
+        function (err, collection) {
+            sthDatabase.getAggrDataFromNativeAggregationPipeline({
+                collection: collection,
+                attrName: request.params.attrName,
+                aggrMethod: request.query.aggrMethod,
+                aggrPeriod: request.query.aggrPeriod,
+                hLimit: request.query.hLimit,
+                from: request.query.dateFrom,
+                to: request.query.dateTo,
+            }, function(err, result) {
+                let response;
+                if (request.query.nongsi) {
+                    const keyLessResult = result.map(res => Object.values(res));
+                    const singleAttributeResult = sthServerUtils.getLWJSingleAttributeResult(request.params.attrName,
+                        Object.keys(result[0]), keyLessResult);
+                    const contextElement = sthServerUtils.getLWJContextElement(request.params.entityId,
+                        request.params.entityType, singleAttributeResult);
+                    response = reply(sthServerUtils.getLWJPayload([contextElement]));
+                } else {
+                    response = reply(
+                        sthServerUtils.getNGSIPayload(
+                            request.params.entityId,
+                            request.params.entityType,
+                            request.params.attrName,
+                            result));
+                }
+                // sthServerUtils.addFiwareTotalCount(totalCount, response);
+                return response;
+            });
+
+        });
+}
+
+/**
+ * @IPPR
  * Returns multiple historical data in an aggregated format
  * This function runs independent of any NGSISTHSINK which has to create aggregated collections beforehand
  * as it aggregates data with the help of MapReduce functions (in-memory)
@@ -780,7 +835,7 @@ function getDataHandler(request, reply) {
   } else if ((request.query.aggrMethod && request.query.hLimit && !request.query.aggrPeriod) ||
       (request.query.aggrMethod && request.query.aggrPeriod && !request.query.hLimit)) {
       request.params.entityId.split(',').length > 1 || request.params.attrName.split(',').length > 1 ?
-          multiMapReduceAggregation(request, reply) : mapReduceAggregation(request, reply);
+          multiMapReduceAggregation(request, reply) : /*mapReduceAggregation(request, reply);*/ nativePipelineAggregation(request, reply);
   } else if (request.query.aggrMethod && request.query.aggrPeriod) {
     // Aggregated data is requested
     getAggregatedData(request, reply);

--- a/lib/server/handlers/sthGetDataHandler.js
+++ b/lib/server/handlers/sthGetDataHandler.js
@@ -998,11 +998,10 @@ function getDataHandler(request, reply) {
   } else if ((request.query.aggrMethod && request.query.hLimit && !request.query.aggrPeriod) ||
       (request.query.aggrMethod && request.query.aggrPeriod && !request.query.hLimit)) {
       if (request.params.entityId.split(',').length > 1 || request.params.attrName.split(',').length > 1) {
-          request.query.nativeAggr ? multiNativeAggregationPipeline(request, reply) : multiMapReduceAggregation(request, reply);
+          request.query.aggrPeriod ? multiNativeAggregationPipeline(request, reply) : multiMapReduceAggregation(request, reply);
       } else {
-          request.query.nativeAggr ? nativePipelineAggregation(request, reply) : mapReduceAggregation(request, reply);
+          request.query.aggrPeriod ? nativePipelineAggregation(request, reply) : mapReduceAggregation(request, reply);
       }
-      // multiMapReduceAggregation(request, reply) : /*mapReduceAggregation(request, reply);*/ nativePipelineAggregation(request, reply);
   } else if (request.query.aggrMethod && request.query.aggrPeriod) {
     // Aggregated data is requested
     getAggregatedData(request, reply);

--- a/lib/server/sthServer.js
+++ b/lib/server/sthServer.js
@@ -102,6 +102,7 @@ function doStartServer(host, port, callback) {
             filetype: joi.string().optional(),
             count: joi.boolean().optional(),
             nongsi: joi.boolean().optional(),
+            nativeAggr: joi.boolean().optional(), // TODO: REMOVE AND REFACTOR
           }
         }
       }

--- a/lib/server/sthServer.js
+++ b/lib/server/sthServer.js
@@ -102,7 +102,6 @@ function doStartServer(host, port, callback) {
             filetype: joi.string().optional(),
             count: joi.boolean().optional(),
             nongsi: joi.boolean().optional(),
-            nativeAggr: joi.boolean().optional(), // TODO: REMOVE AND REFACTOR
           }
         }
       }

--- a/lib/server/utils/sthServerUtils.js
+++ b/lib/server/utils/sthServerUtils.js
@@ -216,7 +216,7 @@ function timeZoneOffsetMillis(utcDateTime, timezone) {
     const utcDate = moment.utc(utcDateTime);
     const local = moment.utc(utcDate).tz(timezone);
     const offset = local.utcOffset(); //in minutes
-    return offset * 60000;
+    return offset * 60000; // offset (hours) * minutes (60) * milliseconds (1000)
 };
 
 
@@ -231,16 +231,19 @@ function timeZoneOffsetMillis(utcDateTime, timezone) {
  * @param attrName string (e.g. 'temperature', 'humidity')
  * @param dateFrom Date
  * @param dateTo Date
+ * @param timeZoneOffsetMillis number (e.g. the timezone offset in milliseconds)
  * @returns Array<Object> The native aggregation pipeline ready to be used with the mongo db.aggregate() method
  */
-function aggregationPipelineBuilder(aggregationMethod, aggregationPeriod, hLimit, attrName, dateFrom, dateTo) {
+function aggregationPipelineBuilder(aggrMethod, aggrPeriod, hLimit, attrName, dateFrom, dateTo, timeZoneOffsetMillis) {
     /* a mapping for the $substr function in order to trim the date for the given aggrPeriod or either use
     * $attrName if no period is specified (e.g. 'hour' trims the ISODate at position 13 to include hours but
-    * exclude minutes and seconds) */
+    * exclude minutes and seconds)
+    */
     const subStrAggrPeriodMap = {'hour': 13, 'day': 10, 'month': 7, 'none': '$attrName'};
-    const aggregationObject = JSON.parse('{"$' + aggregationMethod + '": "$value"}');
-    Object.keys(subStrAggrPeriodMap).indexOf(aggregationPeriod) < 0 ? aggregationPeriod = 'none' : null;
-    if (aggregationPeriod === 'none' && hLimit < 0) {
+    const aggregationObject = JSON.parse('{"$' + aggrMethod + '": "$value"}');
+    const offsetMillis = (aggrPeriod === 'hour' || !timeZoneOffsetMillis) ? 0 : timeZoneOffsetMillis;
+    Object.keys(subStrAggrPeriodMap).indexOf(aggrPeriod) < 0 ? aggrPeriod = 'none' : null;
+    if (aggrPeriod === 'none' && hLimit < 0) {
         throw new Error('AggregationPipelineBuilder: hLimit has to be positive if aggregationPeriod is not being used');
     }
     const aggregationPipeline = [
@@ -256,21 +259,23 @@ function aggregationPipelineBuilder(aggregationMethod, aggregationPeriod, hLimit
         {'$project': {
                 'recvTime': 1,
                 //groupKey = yyyy-mm || yyyy-mm-dd || yyyy-mm-ddTHH || attrName
-                'groupKey': aggregationPeriod === 'none' ? subStrAggrPeriodMap[aggregationPeriod] :
-                    {'$substr': ['$recvTime', 0, subStrAggrPeriodMap[aggregationPeriod]]},
+                // first add a timezoneOffset to UTC timestamp and then make a substring for either hour,day or month
+                'groupKey': aggrPeriod === 'none' ? subStrAggrPeriodMap[aggrPeriod] :
+                    {'$substr': [{ '$add' : [ '$recvTime', offsetMillis ] }, 0,
+                            subStrAggrPeriodMap[aggrPeriod]]},
                 'value': { '$toDouble': '$attrValue'},
                 'attrName':1}
         },
         {'$group':
                 {
                     '_id': '$groupKey',
-                    'firstDate': {'$first': '$recvTime'},
+                    'firstDate': {'$first': { '$add' : [ '$recvTime', offsetMillis ] }},
                     'attrValue': aggregationObject
                 }
         },
         {'$sort': { '_id': 1 } }
     ];
-    aggregationPeriod !== 'none' ? aggregationPipeline.splice(1, 1) : null; // removes the {$limit: hLimit} pipeline
+    aggrPeriod !== 'none' ? aggregationPipeline.splice(1, 1) : null; // removes the {$limit: hLimit} pipeline
     return aggregationPipeline;
 }
 

--- a/lib/server/utils/sthServerUtils.js
+++ b/lib/server/utils/sthServerUtils.js
@@ -26,6 +26,7 @@
 var ROOT_PATH = require('app-root-path');
 var uuid = require('uuid');
 var sthConfig = require(ROOT_PATH + '/lib/configuration/sthConfiguration');
+var moment = require('moment-timezone');
 
 /**
  * Returns the platform correlator if included in a request
@@ -203,6 +204,75 @@ function getLWJPayload(results) {
 }
 
 /**
+ * @IPPR - TimeZoneOffsetMillis Function
+ * This method calculates the offset of the given dateTime in UTC for the given timezone
+ * (see moment.js timezones) in milliseconds
+ * @param utcDateTime Date
+ * @param timezone string (e.g. 'Europe/Vienna')
+ * @returns number The offset in milliseconds
+ */
+function timeZoneOffsetMillis(utcDateTime, timezone) {
+    !timezone ? timezone = 'Europe/Vienna' : null;
+    const utcDate = moment.utc(utcDateTime);
+    const local = moment.utc(utcDate).tz(timezone);
+    const offset = local.utcOffset(); //in minutes
+    return offset * 60000;
+};
+
+
+/**
+ * @IPPR - AggregationPipelineBuilder
+ * This method builds a native aggregation pipeline especially for the aggregation functionality like avg,min and max
+ * and the associated aggregation periods day,month,hour
+ * Should only be used with mongodb version >= 4.x.x
+ * @param aggregationMethod string (e.g. 'avg', 'min', 'max')
+ * @param aggregationPeriod string (e.g. 'hour', 'day', 'month', null)
+ * @param hLimit number (e.g. 3000, 4000, null)
+ * @param attrName string (e.g. 'temperature', 'humidity')
+ * @param dateFrom Date
+ * @param dateTo Date
+ * @returns Array<Object> The native aggregation pipeline ready to be used with the mongo db.aggregate() method
+ */
+function aggregationPipelineBuilder(aggregationMethod, aggregationPeriod, hLimit, attrName, dateFrom, dateTo) {
+    const subStringAggrPeriodMap = {'hour': 13, 'day': 10, 'month': 7, 'none': '$attrName'};
+    const aggregationObject = JSON.parse('{"$' + aggregationMethod + '": "$value"}');
+    Object.keys(subStringAggrPeriodMap).indexOf(aggregationPeriod) < 0 ? aggregationPeriod = 'none' : null;
+    if (aggregationPeriod === 'none' && hLimit < 0) {
+        throw new Error('AggregationPipelineBuilder: hLimit has to be positive if aggregationPeriod is not being used');
+    }
+    const aggregationPipeline = [
+        {'$match':
+                {'$and': [
+                        {'attrName': attrName},
+                        {'recvTime' : {'$gte': dateFrom}},
+                        {'recvTime' : {'$lte': dateTo}}
+                    ]
+                }
+        },
+        {'$limit': hLimit},
+        {'$project': {
+                'recvTime': 1,
+                //groupKey = yyyy-mm || yyyy-mm-dd || yyyy-mm-ddTHH || attrName
+                'groupKey': aggregationPeriod === 'none' ? subStringAggrPeriodMap[aggregationPeriod] :
+                    {'$substr': ['$recvTime', 0, subStringAggrPeriodMap[aggregationPeriod]]},
+                'value': { '$toDouble': '$attrValue'},
+                'attrName':1}
+        },
+        {'$group':
+                {
+                    '_id': '$groupKey',
+                    'firstDate': {'$first': '$recvTime'},
+                    'value': aggregationObject
+                }
+        },
+        {'$sort': { '_id': 1 } }
+    ];
+    aggregationPeriod !== 'none' ? aggregationPipeline.splice(1, 1) : null;
+    return aggregationPipeline;
+}
+
+
+/**
  * Returns the logging context associated to a request
  * @param {Object} request The request received
  * @return {Object} The context to be used for logging
@@ -231,5 +301,7 @@ module.exports = {
     getNGSIMultiContextElementsPayload: getNGSIMultiContextElementsPayload,
     getLWJSingleAttributeResult: getLWJSingleAttributeResult,
     getLWJContextElement: getLWJContextElement,
-    getLWJPayload: getLWJPayload
+    getLWJPayload: getLWJPayload,
+    timeZoneOffsetMillis: timeZoneOffsetMillis,
+    aggregationPipelineBuilder: aggregationPipelineBuilder,
 };

--- a/lib/server/utils/sthServerUtils.js
+++ b/lib/server/utils/sthServerUtils.js
@@ -265,7 +265,7 @@ function aggregationPipelineBuilder(aggregationMethod, aggregationPeriod, hLimit
                 {
                     '_id': '$groupKey',
                     'firstDate': {'$first': '$recvTime'},
-                    'value': aggregationObject
+                    'attrValue': aggregationObject
                 }
         },
         {'$sort': { '_id': 1 } }

--- a/lib/server/utils/sthServerUtils.js
+++ b/lib/server/utils/sthServerUtils.js
@@ -234,9 +234,12 @@ function timeZoneOffsetMillis(utcDateTime, timezone) {
  * @returns Array<Object> The native aggregation pipeline ready to be used with the mongo db.aggregate() method
  */
 function aggregationPipelineBuilder(aggregationMethod, aggregationPeriod, hLimit, attrName, dateFrom, dateTo) {
-    const subStringAggrPeriodMap = {'hour': 13, 'day': 10, 'month': 7, 'none': '$attrName'};
+    /* a mapping for the $substr function in order to trim the date for the given aggrPeriod or either use
+    * $attrName if no period is specified (e.g. 'hour' trims the ISODate at position 13 to include hours but
+    * exclude minutes and seconds) */
+    const subStrAggrPeriodMap = {'hour': 13, 'day': 10, 'month': 7, 'none': '$attrName'};
     const aggregationObject = JSON.parse('{"$' + aggregationMethod + '": "$value"}');
-    Object.keys(subStringAggrPeriodMap).indexOf(aggregationPeriod) < 0 ? aggregationPeriod = 'none' : null;
+    Object.keys(subStrAggrPeriodMap).indexOf(aggregationPeriod) < 0 ? aggregationPeriod = 'none' : null;
     if (aggregationPeriod === 'none' && hLimit < 0) {
         throw new Error('AggregationPipelineBuilder: hLimit has to be positive if aggregationPeriod is not being used');
     }
@@ -253,8 +256,8 @@ function aggregationPipelineBuilder(aggregationMethod, aggregationPeriod, hLimit
         {'$project': {
                 'recvTime': 1,
                 //groupKey = yyyy-mm || yyyy-mm-dd || yyyy-mm-ddTHH || attrName
-                'groupKey': aggregationPeriod === 'none' ? subStringAggrPeriodMap[aggregationPeriod] :
-                    {'$substr': ['$recvTime', 0, subStringAggrPeriodMap[aggregationPeriod]]},
+                'groupKey': aggregationPeriod === 'none' ? subStrAggrPeriodMap[aggregationPeriod] :
+                    {'$substr': ['$recvTime', 0, subStrAggrPeriodMap[aggregationPeriod]]},
                 'value': { '$toDouble': '$attrValue'},
                 'attrName':1}
         },
@@ -267,7 +270,7 @@ function aggregationPipelineBuilder(aggregationMethod, aggregationPeriod, hLimit
         },
         {'$sort': { '_id': 1 } }
     ];
-    aggregationPeriod !== 'none' ? aggregationPipeline.splice(1, 1) : null;
+    aggregationPeriod !== 'none' ? aggregationPipeline.splice(1, 1) : null; // removes the {$limit: hLimit} pipeline
     return aggregationPipeline;
 }
 


### PR DESCRIPTION
### 2019-03-23 & 2019-03-24
- implemented native aggregation pipeline which allows for more performant queries on the mongodb when using `aggrPeriod` to aggregate data.
- aggregations **NOT** using `aggrPeriod` but instead going for the `hLimit` request are automatically calculated by using a MapReduce implementation.
- all aggregation requests using `aggrPeriod` are now calculated by a native aggregation pipeline (🆒 😎 )

### 2019-03-29
- aggregation requests now return the `attrValue` as actual `float` instead of a `string`. The `attrType` field was removed as it is not necessary and saves bandwidth and calculation time.

### 2019-03-31
- added timezoneOffset calculation for the native aggregation pipeline functionality to resolve certain edge cases where unwanted dates would be taken into consideration. This applies especially when `aggrPeriod` is set to either `day` or `month`.
  - Example: `aggrPeriod=day` and `DateFrom=2019-01-01 00:00:00`(LocalTime) -> The aggregation pipeline returns aggregated data for the day `2018-12-31 23:00:00` as the client in the frontend requests data from the comet by providing the already correct date in UTC format.
- adjusted `recvTime` date for aggregation responses where the `HH:MM:SS.fff` portion is normalized and set to `00:00:00.000`.